### PR TITLE
Fixes to file_line resource, syntax of ssl-protocols setting

### DIFF
--- a/hieradata/defaults.yaml
+++ b/hieradata/defaults.yaml
@@ -1,5 +1,5 @@
 ---
 profile::ensuretls::encryptionmode: 'SSLProtocol TLSv1'
-profile::ensuretls::jvmencryptionmode: 'ssl-protocols : ['TLSv1']'
+profile::ensuretls::jvmencryptionmode: 'ssl-protocols : ["TLSv1"]'
 'puppet_enterprise::profile::amq::broker::stomp_transport_options':
   'transport.enabledProtocols': 'TLSv1'

--- a/lib/puppet/provider/file_line/ensuretls.rb
+++ b/lib/puppet/provider/file_line/ensuretls.rb
@@ -7,11 +7,16 @@ Puppet::Type.type(:file_line).provide(:ensuretls) do
   end
 
   def create
+    handled = false
     if resource[:match]
-      handle_create_with_match
-    elsif resource[:after]
-      handle_create_with_after
-    else
+      handled = handle_create_with_match
+    end
+
+    if (!handled) and resource[:after]
+      handled = handle_create_with_after
+    end
+
+    if !handled
       append_line
     end
   end
@@ -44,10 +49,11 @@ Puppet::Type.type(:file_line).provide(:ensuretls) do
         fh.puts(regex.match(l) ? resource[:line] : l)
       end
 
-      if (match_count == 0)
-        fh.puts(resource[:line])
-      end
+      #if (match_count == 0)
+        #fh.puts(resource[:line])
+      #end
     end
+    match_count > 0
   end
 
   def handle_create_with_after
@@ -68,6 +74,7 @@ Puppet::Type.type(:file_line).provide(:ensuretls) do
     else
       raise Puppet::Error, "#{count} lines match pattern '#{resource[:after]}' in file '#{resource[:path]}'.  One or no line must match the pattern."
     end
+    true
   end
 
   def count_matches(regex)

--- a/lib/puppet/provider/file_line/ensuretls.rb
+++ b/lib/puppet/provider/file_line/ensuretls.rb
@@ -1,0 +1,86 @@
+Puppet::Type.type(:file_line).provide(:ensuretls) do
+
+  def exists?
+    lines.find do |line|
+      line.chomp == resource[:line].chomp
+    end
+  end
+
+  def create
+    if resource[:match]
+      handle_create_with_match
+    elsif resource[:after]
+      handle_create_with_after
+    else
+      append_line
+    end
+  end
+
+  def destroy
+    local_lines = lines
+    File.open(resource[:path],'w') do |fh|
+      fh.write(local_lines.reject{|l| l.chomp == resource[:line] }.join(''))
+    end
+  end
+
+  private
+  def lines
+    # If this type is ever used with very large files, we should
+    #  write this in a different way, using a temp
+    #  file; for now assuming that this type is only used on
+    #  small-ish config files that can fit into memory without
+    #  too much trouble.
+    @lines ||= File.readlines(resource[:path])
+  end
+
+  def handle_create_with_match()
+    regex = resource[:match] ? Regexp.new(resource[:match]) : nil
+    match_count = count_matches(regex)
+    if match_count > 1 && resource[:multiple].to_s != 'true'
+     raise Puppet::Error, "More than one line in file '#{resource[:path]}' matches pattern '#{resource[:match]}'"
+    end
+    File.open(resource[:path], 'w') do |fh|
+      lines.each do |l|
+        fh.puts(regex.match(l) ? resource[:line] : l)
+      end
+
+      if (match_count == 0)
+        fh.puts(resource[:line])
+      end
+    end
+  end
+
+  def handle_create_with_after
+    regex = Regexp.new(resource[:after])
+    count = count_matches(regex)
+    case count
+    when 1 # find the line to put our line after
+      File.open(resource[:path], 'w') do |fh|
+        lines.each do |l|
+          fh.puts(l)
+          if regex.match(l) then
+            fh.puts(resource[:line])
+          end
+        end
+      end
+    when 0 # append the line to the end of the file
+      append_line
+    else
+      raise Puppet::Error, "#{count} lines match pattern '#{resource[:after]}' in file '#{resource[:path]}'.  One or no line must match the pattern."
+    end
+  end
+
+  def count_matches(regex)
+    lines.select{|l| l.match(regex)}.size
+  end
+
+  ##
+  # append the line to the file.
+  #
+  # @api private
+  def append_line
+    File.open(resource[:path], 'a') do |fh|
+      fh.puts resource[:line]
+    end
+  end
+end

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -44,22 +44,23 @@ inherits ensuretls::params {
 
   $templatepath='/opt/puppet/share/puppet/modules/puppet_enterprise/templates/master/puppetserver/'
 
-  File_line {
+  file_line {'webserver.conf':
     line   => $jvmencryptionmode,
     ensure => present,
     #match  => "^\\s+ssl-protocols\\s+",
-  }
-
-  file_line {'webserver.conf':
     path   => "${templatepath}/webserver.conf.erb",
     after  => "^\\s+ssl-port\\s+:\\s+8140",
-    notify => Exec['restart-pe-puppetserver'],
+    #notify => Exec['restart-pe-puppetserver'],
+    provider => ensuretls,
   }
 
-  exec { 'restart-pe-puppetserver':
-    command => 'service pe-puppetserver restart',
-    require => File_Line['webserver.conf'],
-    path    => '/sbin'
-  }
+  ### We don't need to restart puppetserver because all we've changed in this run is the
+  ### template.  The actual config file won't get changed until the next agent run, and
+  ### when that happens the server will already get restarted.
+  #exec { 'restart-pe-puppetserver':
+    #command => 'service pe-puppetserver restart',
+    #require => File_Line['webserver.conf'],
+    #path    => '/sbin'
+  #}
 
 }

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -47,7 +47,7 @@ inherits ensuretls::params {
   file_line {'webserver.conf':
     line   => $jvmencryptionmode,
     ensure => present,
-    #match  => "^\\s+ssl-protocols\\s+",
+    match  => "^\\s*ssl-protocols\\s*:",
     path   => "${templatepath}/webserver.conf.erb",
     after  => "^\\s+ssl-port\\s+:\\s+8140",
     #notify => Exec['restart-pe-puppetserver'],

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -47,7 +47,7 @@ inherits ensuretls::params {
   File_line {
     line   => $jvmencryptionmode,
     ensure => present,
-    match  => "^\\s+ssl-protocols\\s+",
+    #match  => "^\\s+ssl-protocols\\s+",
   }
 
   file_line {'webserver.conf':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,4 +1,4 @@
 class ensuretls::params {
   $encryptionmode = 'SSLProtocol TLSv1' 
-  $jvmencryptionmode = 'ssl-protocols: TLSv1'
+  $jvmencryptionmode = 'ssl-protocols: ["TLSv1"]'
 }

--- a/profile-example/profile/manifests/ensuretls/master.pp
+++ b/profile-example/profile/manifests/ensuretls/master.pp
@@ -2,7 +2,8 @@ class profile::ensuretls::master {
 
   class { '::ensuretls::master':
 
-    jvmencryptionmode => hiera('profile::ensuretls::jvmencryptionmode')
+    #jvmencryptionmode => hiera('profile::ensuretls::jvmencryptionmode')
+    jvmencryptionmode => 'ssl-protocols: ["TLSv1"]',
 
   }
 

--- a/profile-example/profile/manifests/ensuretls/master.pp
+++ b/profile-example/profile/manifests/ensuretls/master.pp
@@ -2,8 +2,8 @@ class profile::ensuretls::master {
 
   class { '::ensuretls::master':
 
-    #jvmencryptionmode => hiera('profile::ensuretls::jvmencryptionmode')
-    jvmencryptionmode => 'ssl-protocols: ["TLSv1"]',
+    jvmencryptionmode => hiera('profile::ensuretls::jvmencryptionmode')
+    #jvmencryptionmode => 'ssl-protocols: ["TLSv1"]',
 
   }
 


### PR DESCRIPTION
@DBMoUK i'm not opening this as a real PR, just so you can review the changes I made.

As of the first commit on here, it works for me.  You have to run the agent twice; once to get the template updated and then a second time to make it apply the template, but after that I used openssl s_client and it seemed to be working as expected.

Note that I have the hiera bit commented out here; it's possible that something in the string gets parsed by hiera and then that screws things up; I'll try to add a second commit that goes through hiera.

Also note that I had to turn off the 'match' in the file_line resource, because you can't use both that and 'after', and the 'after' is more important for us.  The obvious flaw in this is that if you ever changed the value, you'd end up with two `ssl-protocols` lines in the template, which would break things.  I can't think of a way to fix that issue without modifying 'file_line', though.  Unless you wanted to overwrite the whole template file, which might be OK as long as you knew for sure that you were targeting a specific PE version.

If necessary we could probably make a copy of the provider code for file_line and include it directly in your ensuretls module, and modify it such that it would accept both 'match' and 'after'.
